### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Utilities for [clojure.spec](https://github.com/clojure/spec.alpha).
 #### Coordinates
 
 ```clojure
-[com.nedap.staffing-solutions/utils.spec "1.0.0-alpha2"]
+[com.nedap.staffing-solutions/utils.spec "1.0.0"]
 ```
 
 > Note that self-hosted ClojureScript (e.g. Lumo) is unsupported at the moment.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.spec "1.0.0-alpha2"
+(defproject com.nedap.staffing-solutions/utils.spec "1.0.0"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[com.nedap.staffing-solutions/utils.test "1.3.0"]
                  [expound "0.7.2"]


### PR DESCRIPTION
## Brief

Remove `alpha` since:

* speced.def shouldn't depend on internal alphas
* no issues have arisen