### PR TITLE
Bump Expound

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
 (defproject com.nedap.staffing-solutions/utils.spec "1.0.0"
   ;; Please keep the dependencies sorted a-z.
-  :dependencies [[expound "0.7.2"]
+  :dependencies [[expound "0.8.4"]
                  [org.clojure/clojure "1.10.1"]
                  [org.clojure/spec.alpha "0.2.176"]
                  [spec-coerce "1.0.0-alpha9"]]


### PR DESCRIPTION
## Brief

Primarily aimed at delivering the supression of its boxed math warnings (https://github.com/bhb/expound/pull/180)

Also, the Expound updates deliver various fixes/improvements (https://github.com/bhb/expound/blob/f938ceb15534f9bec169ca880744659497b29fdf/CHANGELOG.md)

## QA plan

* Bump Expound manually in `speced.def`
  * Suite should still pass
  * Reporting should still work / be readable

...that is exercised in https://circleci.com/gh/nedap/speced.def/253 (with dummy failing tests) which output you can check.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [x] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
