### PR TITLE
[WIP] Report spec failures as literals when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Utilities for [clojure.spec](https://github.com/clojure/spec.alpha).
 #### Coordinates
 
 ```clojure
-[com.nedap.staffing-solutions/utils.spec "1.0.0"]
+[com.nedap.staffing-solutions/utils.spec "1.1.0-alpha2"]
 ```
 
 > Note that self-hosted ClojureScript (e.g. Lumo) is unsupported at the moment.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.spec "1.0.0"
+(defproject com.nedap.staffing-solutions/utils.spec "1.1.0-alpha2"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[expound "0.8.4"]
                  [org.clojure/clojure "1.10.1"]

--- a/src/nedap/utils/spec/impl/check.cljc
+++ b/src/nedap/utils/spec/impl/check.cljc
@@ -35,7 +35,12 @@
                                                                                  (pr-str spec-quoted#)
                                                                                  "\n\n-------------------------"))
                     true                      println)
-                  (throw (ex-info "Validation failed" {:spec         spec-quoted#
-                                                       :faulty-value x-quoted#
-                                                       :explanation  (~explain spec# x#)})))))
+                  (let [should-print-literally?# ((some-fn keyword? set?) spec#)]
+                    (throw (ex-info "Validation failed" (cond-> {:spec         (if should-print-literally?#
+                                                                                 spec#
+                                                                                 spec-quoted#)
+                                                                 :faulty-value x-quoted#
+                                                                 :explanation  (~explain spec# x#)}
+                                                          should-print-literally?#       (assoc :spec-quoted spec-quoted#)
+                                                          (not should-print-literally?#) (assoc :spec-raw spec#))))))))
           true))))

--- a/test/nedap/utils/spec/test_runner.cljs
+++ b/test/nedap/utils/spec/test_runner.cljs
@@ -2,12 +2,14 @@
   (:require
    [cljs.nodejs :as nodejs]
    [nedap.utils.test.api :refer-macros [run-tests]]
-   [unit.nedap.utils.spec.api]))
+   [unit.nedap.utils.spec.api]
+   [unit.nedap.utils.spec.api.check]))
 
 (nodejs/enable-util-print!)
 
 (defn -main []
   (run-tests
-   'unit.nedap.utils.spec.api))
+   'unit.nedap.utils.spec.api
+   'unit.nedap.utils.spec.api.check))
 
 (set! *main-cli-fn* -main)

--- a/test/unit/nedap/utils/spec/api/check.cljc
+++ b/test/unit/nedap/utils/spec/api/check.cljc
@@ -1,0 +1,50 @@
+(ns unit.nedap.utils.spec.api.check
+  (:require
+   #?(:clj [clojure.spec.alpha :as spec] :cljs [cljs.spec.alpha :as spec])
+   #?(:clj [clojure.test :refer [deftest testing are is use-fixtures]] :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
+   [nedap.utils.spec.api :as sut])
+  #?(:clj (:import (clojure.lang ExceptionInfo))))
+
+(spec/def ::number number?)
+
+(defn backed-by-dynamic-spec-checking
+  "A function that performs an `assert` using a dynamic spec.
+
+  This challenges our `check!` helper: it shouldn't report the `'spec` symbol as the relevant spec,
+  but the underlying spec value instead."
+  [spec x]
+  (assert (sut/check! spec x))
+  x)
+
+(deftest reporting
+  (are [desc passed-spec reported-spec reported-quoted-value reported-raw-value]
+      (testing desc
+        (try
+          (with-out-str
+            (backed-by-dynamic-spec-checking passed-spec "NaN"))
+          (is false)
+          (catch ExceptionInfo e
+            (let [{:keys [spec spec-quoted spec-raw]} (-> e ex-data)]
+              (is (= reported-spec
+                     spec))
+              (is (= reported-quoted-value
+                     spec-quoted))
+              (is (= reported-raw-value
+                     spec-raw)))))
+        true)
+    "A `::number` spec is reported as a `::number` (literal keyword),
+    `'spec` is reported as `:spec-quoted`.
+     and nothing is reported as `:spec-raw`"
+    ::number ::number 'spec nil
+
+    "A `#{1 2 3}` spec is reported as `#{1 2 3}` (literal set),
+    `'spec` is reported as `:spec-quoted`.
+     and nothing is reported as `:spec-raw`"
+    #{1 2 3} #{1 2 3} 'spec nil
+
+    ;; note that the following is not ideal,
+    ;; but we cannot possibly get the clean `'number?` symbol out of the `number?` function literal
+    "A `number?` spec is reported as `'spec` (quoted symbol),
+     nothing is reported as `:spec-quoted`,
+     and a function literal is reported as `:spec-raw`"
+    number?  'spec    nil   number?))


### PR DESCRIPTION
## Problem statement

Given dynamic spec checking such as the following:

```clj
(defn backed-by-dynamic-spec-checking
  "A function that performs an `assert` using a dynamic (parameterized) spec.

  This challenges our `check!` helper: it shouldn't report the `'spec` symbol as the relevant spec,
  but the underlying spec value instead."
  [spec x]
  (assert (sut/check! spec x))
  x)
```

...the ex-data emitted by `check!` will be somewhat useless: it'll report `:spec 'spec` instead of `:spec ::the-actual-spec`.

That was implemented like that for a good reason: a function literal `number?` or a spec object created with `(spec/spec ...)` have ugly representations when printed. Passing a quoted symbol instead tends to be more useful, since it relates more directly to our actual codebases.

> Note that aside from `:spec`, an `:explanation` entry is always passed, and is always useful/accurate.

I think that for keywords and sets, :spec should be associated to a literal value, and for everything else, things should remain as-usual.

For aiding debugging, extra keys will also be passed. See diff.

## Use case

Thanks to this PR, one can cover with tests a  "dynamic" defn in the style of the `backed-by-dynamic-spec-checking` using our `assertion-thrown?` helper:

```clj
(is (spec-assertion-thrown? ::number ...))
(is (spec-assertion-thrown? #{1 2 3} ...))
;; currently, the examples above only work if the code that threw the exception wasn't dynamic in its spec checking.
```

## QA plan

* Tests included
* Consume the alpha, hit `spec-assertion-thrown?`. I got it working as expected:

![image](https://user-images.githubusercontent.com/1162994/71690411-f108e580-2da4-11ea-84fd-d0c480ac15e4.png)

...in the screenshot, you'll notice that `(is (spec-assertion-thrown? 'spec (backed-by-dynamic-spec-checking number? ::foo)))` isn't particularly expressive ('spec doesn't say much).

That exactly the behavior prior to this PR. I'd improve it in a new PR.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [ ] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [ ] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
